### PR TITLE
add support for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# https://pythonspeed.com/articles/conda-docker-image-size/
+
+FROM continuumio/miniconda3 AS build
+
+# Install the package as normal:
+COPY environment.yml .
+RUN conda env create -f environment.yml
+
+# COPY requirements.txt .
+# RUN conda create --name env --file requirements.txt
+
+# Install conda-pack:
+RUN conda install -c conda-forge conda-pack
+
+# Use conda-pack to create a standalone enviornment
+# in /venv:
+RUN conda-pack -n example -o /tmp/env.tar && \
+  mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
+  rm /tmp/env.tar
+
+# We've put venv in same path it'll be in final image,
+# so now fix up paths:
+RUN /venv/bin/conda-unpack
+
+
+# The runtime-stage image; we can use Debian as the
+# base image since the Conda env also includes Python
+# for us.
+FROM debian:buster AS runtime
+
+# Copy /venv from the previous stage:
+COPY --from=build /venv /venv
+
+ADD app /app
+ADD app.py .
+# When image is run, run the code with the environment
+# activated:
+SHELL ["/bin/bash", "-c"]
+ENTRYPOINT source /venv/bin/activate && \
+           python app.py

--- a/README.md
+++ b/README.md
@@ -21,3 +21,14 @@ If the clone is too slow, you can use the following method
 ```shell script
 $ # git clone --depth 1 https://github.com.cnpmjs.org/InnoFang/what-digit-you-write.git 
 ```
+
+### docker env
+
+see `Dockerfile` for how the environment is built
+
+````
+$ git clone --depth 1 https://github.com/InnoFang/what-digit-you-write.git
+$ cd what-digit-you-write
+$ docker build -t ml-digit .
+$ docker run -it -p 5000:5000 ml-digit
+````

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
 from app import app
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(host= '0.0.0.0', debug=True)

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+name: example
+channels:
+  - conda-forge
+dependencies:
+  - tensorflow=2.3.0
+  - cudatoolkit=10.1.243
+  - cudnn=7.6.5
+  - matplotlib>=3.3.1
+  - numpy>=1.19.1
+  - flask>=1.1.2
+


### PR DESCRIPTION
contribute the `Dockerfile` to be reproduce the environment easily, the tensonflow is changed to `2.3.0` (`2.1.0` meets module issue, latest `2.4.0` doesn't exist in `conda` environment

BTW: this is an excellent GUI demo for this well known ML basic training